### PR TITLE
Implement the getParameters method in abstract provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ If you are working with a job listing service not supported out-of-the-box or by
 abstract public function createJobObject($payload);
 abstract public function getFormat();
 abstract public function getListingsPath();
-abstract public function getParameters();
 abstract public function getUrl();
 abstract public function getVerb();
 ```

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -166,7 +166,10 @@ abstract class AbstractProvider
      *
      * @return  array
      */
-    abstract public function getParameters();
+    public function getParameters()
+    {
+        return [];
+    }
 
     /**
      * Get raw listings from payload

--- a/test/src/ProviderTest.php
+++ b/test/src/ProviderTest.php
@@ -15,6 +15,13 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
             ->shouldAllowMockingProtectedMethods();
     }
 
+    public function testGetParameters()
+    {
+        $parameters = $this->client->getParameters();
+
+        $this->assertEquals([], $parameters);
+    }
+
     public function testItPopulatesExistingAttributeswhenBuilt()
     {
         $attributes = [


### PR DESCRIPTION
Per conversation in #7, the `AbstractProvider` now implements the getParameters method. Any consuming providers that wish to change this behavior will need to override the method.
