### PR TITLE
Allow installation of both `guzzlehttp/guzzle` : `^6.0` & `^7.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.6",


### PR DESCRIPTION
Fixes https://github.com/jobapis/jobs-common/issues/30